### PR TITLE
Add rendering service wrapping the official Anki engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ node_modules/
 .DS_Store
 Thumbs.db
 SIGNAL.txt
+
+# Python rendering service
+server/.venv/
+server/data/
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,8 +1,46 @@
 # anki-renderer
 
-Anki card template renderer compiled to WebAssembly.
+Pixel-accurate Anki card previews for web apps.
 
-**[Live Demo](https://anki-renderer.bjblabs.com)** | [GitHub](https://github.com/Gilbetrar/anki-renderer)
+**[Live Demo](https://anki-renderer.bjblabs.com)** | **Rendering API:** `https://anki-renderer.bjblabs.com/api/render` | [GitHub](https://github.com/Gilbetrar/anki-renderer)
+
+## Rendering service (current approach)
+
+`server/` wraps the **official `anki` Python package** — Anki's real Rust
+rendering engine — in a small FastAPI service. Output is byte-identical to
+what Anki desktop renders (verified against a live collection: 102/102 cards
+across 17 note types, including image occlusion, cloze, and type-in-answer).
+There is no reimplemented template engine to drift out of sync.
+
+```bash
+curl -s https://anki-renderer.bjblabs.com/api/render \
+  -H 'Content-Type: application/json' -d '{
+    "templates": [{"front": "{{Front}}", "back": "{{FrontSide}}<hr id=answer>{{Back}}"}],
+    "fields": {"Front": "What is 2 + 2?", "Back": "4"}
+  }'
+```
+
+Response: one entry per card with `question`/`answer` HTML, `empty` (would
+Anki generate this card?), extracted audio/TTS tags, plus the note type CSS
+and engine version. Cloze note types (`"cloze": true`) return one card per
+cloze ordinal. `deckName`, `tags`, and `modelName` are honored so special
+fields (`{{Deck}}`, `{{Tags}}`, `{{Type}}`, …) render correctly.
+
+Run locally:
+
+```bash
+cd server && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt
+cd .. && server/.venv/bin/uvicorn server.app:app --port 9003   # from repo root
+server/.venv/bin/python -m pytest server/tests/                # test suite
+server/.venv/bin/python -m server.differential                 # fidelity check vs live Anki (needs AnkiConnect)
+```
+
+## WASM renderer (legacy)
+
+The original approach below — a Rust reimplementation of Anki's template
+engine compiled to WebAssembly — still powers the demo site, but has known
+fidelity gaps (see issue #20 and API.md) and is superseded by the rendering
+service for accuracy-critical use.
 
 ## Features
 

--- a/server/app.py
+++ b/server/app.py
@@ -1,0 +1,72 @@
+"""HTTP API for the Anki rendering service.
+
+POST /render — render templates + fields through Anki's real engine.
+GET  /healthz — liveness check with engine version.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
+from anki.errors import CardTypeError, TemplateError
+
+from .renderer import ANKI_VERSION, RenderRequest, RenderService, TemplateSpec
+
+
+class TemplateIn(BaseModel):
+    front: str
+    back: str
+    name: str = "Card 1"
+
+
+class RenderIn(BaseModel):
+    templates: list[TemplateIn] = Field(min_length=1)
+    fields: dict[str, str] = Field(min_length=1)
+    css: str | None = None
+    modelName: str = "Preview"
+    cloze: bool = False
+    deckName: str = "Default"
+    tags: list[str] = []
+    fillEmpty: bool = False
+
+
+app = FastAPI(title="anki-renderer", version=ANKI_VERSION)
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+service = RenderService(data_dir=os.environ.get("ANKI_RENDER_DATA_DIR"))
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"ok": True, "ankiVersion": ANKI_VERSION}
+
+
+@app.post("/render")
+def render(body: RenderIn) -> dict:
+    req = RenderRequest(
+        templates=[TemplateSpec(front=t.front, back=t.back, name=t.name) for t in body.templates],
+        fields=body.fields,
+        css=body.css,
+        model_name=body.modelName,
+        cloze=body.cloze,
+        deck_name=body.deckName,
+        tags=body.tags,
+        fill_empty=body.fillEmpty,
+    )
+    try:
+        return service.render(req)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except KeyError as e:
+        raise HTTPException(status_code=400, detail=f"unknown field: {e}")
+    except (CardTypeError, TemplateError) as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/server/differential.py
+++ b/server/differential.py
@@ -1,0 +1,104 @@
+"""Differential fidelity check: render real cards from the live Anki
+collection (via AnkiConnect) through RenderService, and byte-compare with
+the HTML the running Anki app itself produced (cardsInfo).
+
+Usage: .venv/bin/python -m server.differential [notes-per-model]
+Exit code 0 = all sampled cards match exactly.
+"""
+
+from __future__ import annotations
+
+import difflib
+import sys
+
+import requests
+
+from server.renderer import RenderRequest, RenderService, TemplateSpec
+
+ANKICONNECT = "http://localhost:8765"
+
+
+def ac(action: str, **params):
+    r = requests.post(ANKICONNECT, json={"action": action, "version": 6, "params": params}, timeout=30)
+    r.raise_for_status()
+    body = r.json()
+    if body.get("error"):
+        raise RuntimeError(f"AnkiConnect {action}: {body['error']}")
+    return body["result"]
+
+
+def main(notes_per_model: int = 3) -> int:
+    svc = RenderService()
+    models = ac("modelNames")
+    total = matched = 0
+    failures: list[str] = []
+
+    for model in models:
+        templates = ac("modelTemplates", modelName=model)
+        css = ac("modelStyling", modelName=model)["css"]
+        note_ids = ac("findNotes", query=f'note:"{model}"')[:notes_per_model]
+        if not note_ids:
+            print(f"  (no notes) {model}")
+            continue
+        notes = ac("notesInfo", notes=note_ids)
+
+        for note in notes:
+            fields = {
+                name: info["value"]
+                for name, info in sorted(note["fields"].items(), key=lambda kv: kv[1]["order"])
+            }
+            card_infos = ac("cardsInfo", cards=note["cards"])
+            if not card_infos:
+                continue
+            is_cloze = any("{{c" in v for v in fields.values()) and any(
+                "cloze:" in t["Front"] for t in templates.values()
+            )
+            out = svc.render(RenderRequest(
+                templates=[TemplateSpec(front=t["Front"], back=t["Back"], name=name)
+                           for name, t in templates.items()],
+                fields=fields,
+                css=css,
+                model_name=model,
+                cloze=is_cloze,
+                deck_name=card_infos[0]["deckName"],
+                tags=note.get("tags", []),
+            ))
+            ours_by_ord = {c["ord"]: c for c in out["cards"]}
+
+            for ci in card_infos:
+                total += 1
+                ours = ours_by_ord.get(ci["ord"])
+                if ours is None:
+                    failures.append(f"{model} note {note['noteId']} ord {ci['ord']}: not rendered by service")
+                    continue
+                ok = True
+                for side, live_key in (("question", "question"), ("answer", "answer")):
+                    # AnkiConnect's cardsInfo returns card.question()/answer(),
+                    # which prepend the notetype CSS in a <style> block.
+                    live = ci[live_key]
+                    mine = f"<style>{out['css']}</style>{ours[side]}"
+                    if live != mine:
+                        ok = False
+                        diff = "\n".join(difflib.unified_diff(
+                            live.splitlines(), mine.splitlines(),
+                            "live-anki", "service", lineterm="", n=1))[:1500]
+                        failures.append(
+                            f"{model} note {note['noteId']} ord {ci['ord']} {side} differs:\n{diff}")
+                if ok:
+                    matched += 1
+        print(f"  checked {model}")
+
+    svc.close()
+    print(f"\n{matched}/{total} cards matched exactly")
+    if failures:
+        print(f"\n{len(failures)} mismatches:")
+        for f in failures:
+            print("-" * 60)
+            print(f)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    n = int(sys.argv[1]) if len(sys.argv) > 1 else 3
+    sys.exit(main(n))

--- a/server/renderer.py
+++ b/server/renderer.py
@@ -1,0 +1,171 @@
+"""Core rendering logic: wraps the official anki package so every card is
+rendered by Anki's real Rust engine, via the same code path Anki desktop's
+card-layout preview uses (TemplateRenderContext.from_card_layout)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import threading
+from dataclasses import dataclass, field
+
+import anki.collection  # noqa: F401  (must import before anki.template — circular import)
+import anki.buildinfo
+from anki.cards import Card
+from anki.collection import Collection
+from anki.template import TemplateRenderContext
+
+ANKI_VERSION = anki.buildinfo.version
+
+
+@dataclass
+class TemplateSpec:
+    front: str
+    back: str
+    name: str = "Card 1"
+
+
+@dataclass
+class RenderRequest:
+    templates: list[TemplateSpec]
+    fields: dict[str, str]
+    css: str | None = None
+    model_name: str = "Preview"
+    cloze: bool = False
+    deck_name: str = "Default"
+    tags: list[str] = field(default_factory=list)
+    fill_empty: bool = False
+
+
+class RenderService:
+    """Holds one scratch Collection; renders requests against ephemeral
+    notetypes/notes that are removed again after each render.
+
+    Collection is not thread-safe, so all rendering is serialized."""
+
+    def __init__(self, data_dir: str | None = None):
+        self._lock = threading.Lock()
+        self._dir = data_dir or tempfile.mkdtemp(prefix="anki-render-")
+        os.makedirs(self._dir, exist_ok=True)
+        self._col_path = os.path.join(self._dir, "scratch.anki2")
+        self._col = Collection(self._col_path)
+
+    def close(self) -> None:
+        with self._lock:
+            self._col.close()
+
+    def render(self, req: RenderRequest) -> dict:
+        with self._lock:
+            try:
+                return self._render(req)
+            except Exception:
+                # A failed render can leave the scratch collection in a bad
+                # state; rebuild it so one bad request can't poison the next.
+                self._reset_collection()
+                raise
+
+    def _reset_collection(self) -> None:
+        try:
+            self._col.close()
+        except Exception:
+            pass
+        for suffix in ("", "-wal", "-shm"):
+            try:
+                os.remove(self._col_path + suffix)
+            except FileNotFoundError:
+                pass
+        self._col = Collection(self._col_path)
+
+    def _render(self, req: RenderRequest) -> dict:
+        col = self._col
+        mm = col.models
+
+        if not req.templates:
+            raise ValueError("at least one template is required")
+        if not req.fields:
+            raise ValueError("at least one field is required")
+
+        notetype = mm.new(req.model_name)
+        if req.cloze:
+            notetype["type"] = 1
+        for fname in req.fields:
+            mm.add_field(notetype, mm.new_field(fname))
+        for spec in req.templates:
+            tpl = mm.new_template(spec.name)
+            tpl["qfmt"] = spec.front
+            tpl["afmt"] = spec.back
+            mm.add_template(notetype, tpl)
+        if req.css is not None:
+            notetype["css"] = req.css
+        mm.add(notetype)
+
+        note = None
+        try:
+            note = col.new_note(notetype)
+            for name, value in req.fields.items():
+                note[name] = value
+            note.tags = list(req.tags)
+
+            deck_id = col.decks.id(req.deck_name)
+            # Persist the note so cards render through the exact same path a
+            # real review uses (deck names, card generation rules included).
+            col.add_note(note, deck_id=deck_id)
+            real_cards = {c.ord: c for c in note.cards()}
+
+            if req.cloze:
+                ordinals = sorted(real_cards) or [0]
+                jobs = [(o, notetype["tmpls"][0]) for o in ordinals]
+            else:
+                jobs = list(enumerate(notetype["tmpls"]))
+
+            cards = []
+            for ord_, tpl in jobs:
+                card = real_cards.get(ord_)
+                if card is not None:
+                    out = card.render_output(reload=True)
+                    empty = False
+                else:
+                    # Anki would not generate this card (front renders empty).
+                    # Render it anyway via the card-layout preview path so the
+                    # author can still see the template.
+                    card = Card(col)
+                    card.ord = ord_
+                    card.did = deck_id
+                    ctx = TemplateRenderContext.from_card_layout(
+                        note, card, notetype=notetype, template=tpl,
+                        fill_empty=req.fill_empty,
+                    )
+                    out = ctx.render()
+                    empty = True
+                cards.append({
+                    "ord": ord_,
+                    "name": tpl["name"],
+                    "empty": empty,
+                    "question": out.question_text,
+                    "answer": out.answer_text,
+                    "questionAvTags": [_av_tag_dict(t) for t in out.question_av_tags],
+                    "answerAvTags": [_av_tag_dict(t) for t in out.answer_av_tags],
+                })
+
+            return {
+                "cards": cards,
+                "css": notetype["css"],
+                "ankiVersion": ANKI_VERSION,
+            }
+        finally:
+            if note is not None and note.id:
+                col.remove_notes([note.id])
+            mm.remove(notetype["id"])
+
+
+def _av_tag_dict(tag) -> dict:
+    # TTSTag has field_text/lang/voices/speed; SoundOrVideoTag has filename.
+    if hasattr(tag, "filename"):
+        return {"kind": "sound", "filename": tag.filename}
+    return {
+        "kind": "tts",
+        "fieldText": tag.field_text,
+        "lang": tag.lang,
+        "voices": list(tag.voices),
+        "speed": tag.speed,
+    }

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,6 @@
+anki==25.9.4
+fastapi>=0.115
+uvicorn[standard]>=0.30
+pytest>=8
+httpx>=0.27
+requests>=2.32

--- a/server/tests/test_api.py
+++ b/server/tests/test_api.py
@@ -1,0 +1,46 @@
+from fastapi.testclient import TestClient
+
+from server.app import app
+
+client = TestClient(app)
+
+
+def test_healthz():
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+
+def test_render_endpoint():
+    r = client.post("/render", json={
+        "templates": [{"front": "{{Front}}", "back": "{{FrontSide}}<hr>{{Back}}"}],
+        "fields": {"Front": "2+2?", "Back": "4"},
+    })
+    assert r.status_code == 200
+    body = r.json()
+    assert body["cards"][0]["question"] == "2+2?"
+    assert body["cards"][0]["answer"] == "2+2?<hr>4"
+    assert body["ankiVersion"]
+
+
+def test_render_cloze_endpoint():
+    r = client.post("/render", json={
+        "templates": [{"front": "{{cloze:Text}}", "back": "{{cloze:Text}}"}],
+        "fields": {"Text": "{{c1::a}} {{c2::b}}"},
+        "cloze": True,
+    })
+    assert r.status_code == 200
+    assert len(r.json()["cards"]) == 2
+
+
+def test_validation_error():
+    r = client.post("/render", json={"templates": [], "fields": {}})
+    assert r.status_code == 422
+
+
+def test_cors_header():
+    r = client.post("/render", headers={"Origin": "https://example.com"}, json={
+        "templates": [{"front": "{{F}}", "back": "x"}],
+        "fields": {"F": "y"},
+    })
+    assert r.headers.get("access-control-allow-origin") == "*"

--- a/server/tests/test_renderer.py
+++ b/server/tests/test_renderer.py
@@ -1,0 +1,154 @@
+import pytest
+
+from server.renderer import RenderRequest, RenderService, TemplateSpec
+
+
+@pytest.fixture(scope="module")
+def svc(tmp_path_factory):
+    s = RenderService(data_dir=str(tmp_path_factory.mktemp("col")))
+    yield s
+    s.close()
+
+
+def render(svc, **kw):
+    defaults = dict(
+        templates=[TemplateSpec(front="{{Front}}", back="{{FrontSide}}<hr id=answer>{{Back}}")],
+        fields={"Front": "Q", "Back": "A"},
+    )
+    defaults.update(kw)
+    return svc.render(RenderRequest(**defaults))
+
+
+def test_basic_card(svc):
+    out = render(svc)
+    assert out["cards"][0]["question"] == "Q"
+    assert out["cards"][0]["answer"] == "Q<hr id=answer>A"
+
+
+def test_issue20_field_names_with_punctuation(svc):
+    name = "Source (book, article, etc.)"
+    tpl = TemplateSpec(
+        front="{{#%s}}<p>{{%s}}</p>{{/%s}}x" % (name, name, name),
+        back="{{FrontSide}}",
+    )
+    out = render(svc, templates=[tpl], fields={name: "Bk"})
+    assert out["cards"][0]["question"] == "<p>Bk</p>x"
+
+    # With the field empty the conditional drops out. Only field replacements
+    # count toward a non-blank front, so Anki appends its blank-front notice
+    # after the literal "x" — but still generates card 1 (a note always gets
+    # at least one card).
+    out = render(svc, templates=[tpl], fields={name: "", "Other": "y"})
+    q = out["cards"][0]["question"]
+    assert q.startswith("x") and "blank" in q
+    assert out["cards"][0]["empty"] is False
+
+
+def test_card_anki_would_not_generate_is_flagged_empty(svc):
+    # Card 1 always exists, so use a second template with a blank front:
+    # Anki does not generate that card, but we still preview it.
+    out = render(
+        svc,
+        templates=[
+            TemplateSpec(front="{{A}}", back="x", name="T1"),
+            TemplateSpec(front="{{#B}}{{B}}{{/B}}", back="y", name="T2"),
+        ],
+        fields={"A": "a", "B": ""},
+    )
+    assert out["cards"][0]["empty"] is False
+    assert out["cards"][1]["empty"] is True
+    assert "blank" in out["cards"][1]["question"]
+
+
+def test_cloze_generates_card_per_ordinal(svc):
+    out = render(
+        svc,
+        templates=[TemplateSpec(front="{{cloze:Text}}", back="{{cloze:Text}}")],
+        fields={"Text": "{{c1::alpha}} then {{c2::beta::hint}}"},
+        cloze=True,
+    )
+    assert [c["ord"] for c in out["cards"]] == [0, 1]
+    q1, q2 = out["cards"][0]["question"], out["cards"][1]["question"]
+    # Modern Anki hides the answer in the visible text but carries it in the
+    # data-cloze attribute (used by its show-answer interactivity).
+    assert '>[...]</span>' in q1 and 'data-cloze="alpha"' in q1
+    assert ">[hint]</span>" in q2 and 'data-cloze="beta"' in q2
+    assert ">alpha</span>" in out["cards"][0]["answer"]
+
+
+def test_cloze_field_name_with_ampersand(svc):
+    out = render(
+        svc,
+        templates=[TemplateSpec(
+            front="{{cloze:Cloze Question & Answer}}",
+            back="{{cloze:Cloze Question & Answer}}",
+        )],
+        fields={"Cloze Question & Answer": "x {{c1::y}}"},
+        cloze=True,
+    )
+    assert "cloze" in out["cards"][0]["question"]
+    assert "y" in out["cards"][0]["answer"]
+
+
+def test_multiple_templates_render_all_cards(svc):
+    out = render(
+        svc,
+        templates=[
+            TemplateSpec(front="{{Front}}", back="{{Back}}", name="Forward"),
+            TemplateSpec(front="{{Back}}", back="{{Front}}", name="Reverse"),
+        ],
+    )
+    assert [c["name"] for c in out["cards"]] == ["Forward", "Reverse"]
+    assert out["cards"][1]["question"] == "A"
+
+
+def test_special_fields(svc):
+    out = render(
+        svc,
+        templates=[TemplateSpec(front="{{Deck}}|{{Subdeck}}|{{Card}}|{{Tags}}|{{Type}}|{{Front}}", back="x")],
+        deck_name="Parent::Child",
+        tags=["t1", "t2"],
+        model_name="MyModel",
+    )
+    q = out["cards"][0]["question"]
+    assert q == "Parent::Child|Child|Card 1|t1 t2|MyModel|Q"
+
+
+def test_sound_tags_extracted(svc):
+    out = render(
+        svc,
+        templates=[TemplateSpec(front="{{Front}}", back="x")],
+        fields={"Front": "hello [sound:beep.mp3]"},
+    )
+    card = out["cards"][0]
+    assert card["questionAvTags"] == [{"kind": "sound", "filename": "beep.mp3"}]
+    assert "[anki:play:q:0]" in card["question"]
+
+
+def test_css_passthrough(svc):
+    out = render(svc, css=".card { color: red; }")
+    assert out["css"] == ".card { color: red; }"
+
+
+def test_default_css_when_unspecified(svc):
+    out = render(svc)
+    assert ".card" in out["css"]
+
+
+def test_unknown_field_in_template_raises(svc):
+    # Anki raises CardTypeError for a template referencing a missing field;
+    # the API layer turns this into a 4xx.
+    from anki.errors import CardTypeError
+    with pytest.raises(CardTypeError):
+        render(svc, templates=[TemplateSpec(front="{{Nope}}", back="x")])
+
+
+def test_bad_request_rejected(svc):
+    with pytest.raises(ValueError):
+        svc.render(RenderRequest(templates=[], fields={"a": "b"}))
+
+
+def test_collection_survives_failed_render(svc):
+    with pytest.raises(ValueError):
+        svc.render(RenderRequest(templates=[], fields={"a": "b"}))
+    assert render(svc)["cards"][0]["question"] == "Q"


### PR DESCRIPTION
## What

A FastAPI service (`server/`) that wraps the official `anki` PyPI package — Anki's real Rust rendering engine, using the same code paths Anki desktop uses (real persisted notes; card-layout preview only as fallback for cards Anki wouldn't generate).

## Why

The WASM reimplementation can never be fully trusted: it fails on real field names (#20), and its tests only assert what we *believed* Anki does. Wrapping the official engine makes fidelity true by construction — including behaviors we'd never have guessed (literal text doesn't count toward a non-blank front; card 1 is always generated; cloze answers ride in `data-cloze` attributes).

## Verification

- 18 pytest tests (`server/tests/`)
- **Differential check** (`server/differential.py`): pulled every note type from the live collection via AnkiConnect, rendered 102 cards through the service, byte-compared against the running Anki app's own output: **102/102 exact matches** — image occlusion SVG, cloze, type-in-answer, JS map decks, all of it.

## Deployment

Live at `https://anki-renderer.bjblabs.com/api/render` (port 9003, launchd `com.anki-renderer.render`) — infra documented in mac-mini-server#28.

## Follow-ups (separate issues)

- Point the web component / demo at the service
- Decide the WASM renderer's fate (parked vs. removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)