### PR TITLE
Repoint web component & demo at the official-engine rendering service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,36 @@ jobs:
       - name: Run Jest tests
         run: npm run test:js
 
+      - name: Setup Python (for the rendering service used by e2e tests)
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install rendering service dependencies
+        run: |
+          python -m venv server/.venv
+          server/.venv/bin/pip install -r server/requirements.txt
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
       - name: Run Playwright tests
         run: npm run test:e2e
+
+  server-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install -r server/requirements.txt
+
+      - name: Run server tests
+        run: python -m pytest server/tests/

--- a/README.md
+++ b/README.md
@@ -35,12 +35,58 @@ server/.venv/bin/python -m pytest server/tests/                # test suite
 server/.venv/bin/python -m server.differential                 # fidelity check vs live Anki (needs AnkiConnect)
 ```
 
+## Web component
+
+`<anki-card-preview>` renders cards through the service (no WASM in the
+component bundle):
+
+```html
+<script type="module">
+  import 'anki-renderer/component';
+</script>
+
+<anki-card-preview
+  template-front="{{Front}}"
+  template-back="{{FrontSide}}<hr>{{Back}}"
+  fields='{"Front": "Hello", "Back": "World"}'
+  side="question"
+></anki-card-preview>
+```
+
+Attributes:
+
+- `template-front` / `template-back` — card templates
+- `fields` — JSON object of field name/value pairs
+- `side` — `question` or `answer`
+- `cloze` — boolean attribute; treat the note type as cloze (the service
+  returns one card per cloze ordinal)
+- `card-ord` — which card to display, by 0-indexed ordinal (defaults to the
+  first card Anki would generate)
+- `css` — note type CSS (replaces Anki's stock `.card` css, as in Anki)
+- `night-mode` — boolean attribute; applies `night_mode`/`nightMode` classes
+  and dark base styles
+- `service-url` — rendering service base URL (defaults to the public service)
+
+Events: `render-complete` (detail: `content`, `side`, `card`, `cards`,
+`ankiVersion`) and `render-error` (detail: `message`, `error`). Attribute
+changes are debounced into a single re-render.
+
+### Limitations
+
+- **Media files are not served.** `<img>` tags in fields render as-is, so
+  images stored in Anki's media folder won't resolve unless the page can
+  reach them by the same path.
+- **No audio playback or type-in grading.** Audio/TTS tags render as a ▶
+  placeholder; the parsed tags are available on `render-complete` via
+  `card.questionAvTags` / `card.answerAvTags`.
+
 ## WASM renderer (legacy)
 
 The original approach below — a Rust reimplementation of Anki's template
-engine compiled to WebAssembly — still powers the demo site, but has known
-fidelity gaps (see issue #20 and API.md) and is superseded by the rendering
-service for accuracy-critical use.
+engine compiled to WebAssembly — is still available as the `renderCard`
+JavaScript API, but has known fidelity gaps (see issue #20 and API.md) and
+is superseded by the rendering service for accuracy-critical use. The demo
+site and web component now use the service.
 
 ## Features
 
@@ -48,7 +94,6 @@ service for accuracy-critical use.
 - Cloze deletions (`{{c1::text}}`, `{{c1::text::hint}}`)
 - Template filters (`text`, `hint`, `type`, `furigana`, `kanji`, `kana`)
 - TypeScript/JavaScript bindings with ergonomic API
-- Web component (`<anki-card-preview>`) for easy embedding
 - CSS styling support (default Anki styles, night mode, custom CSS)
 
 ## Installation
@@ -76,22 +121,6 @@ console.log(result.question); // "What is 2 + 2?"
 console.log(result.answer);   // "What is 2 + 2?<hr>4"
 ```
 
-### Web Component
-
-```html
-<script type="module">
-  import 'anki-renderer/component';
-</script>
-
-<anki-card-preview
-  template-front="{{Front}}"
-  template-back="{{FrontSide}}<hr>{{Back}}"
-  fields='{"Front": "Hello", "Back": "World"}'
-  side="question"
-  default-styles
-></anki-card-preview>
-```
-
 ## Development
 
 ### Prerequisites
@@ -117,7 +146,8 @@ npm run build:ts                         # TypeScript
 ```bash
 cargo test          # Rust tests
 npm run test:js     # Jest tests
-npm run test:e2e    # Playwright tests
+npm run test:e2e    # Playwright tests (starts the rendering service from server/.venv)
+server/.venv/bin/python -m pytest server/tests/   # rendering service tests
 ```
 
 ### Demo Site

--- a/demo/index.html
+++ b/demo/index.html
@@ -9,7 +9,7 @@
 <body>
   <header>
     <h1>anki-renderer</h1>
-    <p class="tagline">Anki card template renderer compiled to WebAssembly</p>
+    <p class="tagline">Pixel-accurate Anki card previews, rendered by Anki's official engine</p>
     <nav>
       <a href="#demo">Demo</a>
       <a href="#examples">Examples</a>
@@ -42,21 +42,21 @@
 
           <div class="options-row">
             <div class="editor-group">
-              <label for="card-ordinal">Cloze Card # (0 for non-cloze)</label>
-              <input type="number" id="card-ordinal" value="0" min="0">
+              <label for="card-ord">Card ordinal (0 = first card / first cloze)</label>
+              <input type="number" id="card-ord" value="0" min="0">
             </div>
             <div class="checkbox-group">
               <label>
-                <input type="checkbox" id="night-mode"> Night Mode
+                <input type="checkbox" id="cloze"> Cloze Note Type
               </label>
               <label>
-                <input type="checkbox" id="default-styles" checked> Default Styles
+                <input type="checkbox" id="night-mode"> Night Mode
               </label>
             </div>
           </div>
 
           <div class="editor-group">
-            <label for="custom-css">Custom CSS (optional)</label>
+            <label for="custom-css">Note type CSS (optional — defaults to Anki's stock styling)</label>
             <textarea id="custom-css" rows="3" placeholder=".card { font-size: 24px; }"></textarea>
           </div>
         </div>
@@ -112,7 +112,13 @@
 
         <div class="example-card" data-example="filters">
           <h3>Filters</h3>
-          <p>Text processing with filters like text: and type:.</p>
+          <p>Text processing with filters like text:.</p>
+          <button class="try-btn">Try it</button>
+        </div>
+
+        <div class="example-card" data-example="punctuated">
+          <h3>Punctuated Field Names</h3>
+          <p>Field names with parentheses and commas — exactly as Anki handles them.</p>
           <button class="try-btn">Try it</button>
         </div>
       </div>
@@ -122,57 +128,16 @@
       <h2>API Reference</h2>
 
       <div class="api-section">
-        <h3>Installation</h3>
-        <pre><code>npm install anki-renderer</code></pre>
-      </div>
-
-      <div class="api-section">
-        <h3>Basic Usage</h3>
-        <pre><code>import { renderCard, initWasm } from 'anki-renderer';
-
-// Initialize WASM (optional - auto-initializes on first render)
-await initWasm();
-
-// Render a card
-const result = await renderCard({
-  front: "{{Front}}",
-  back: "{{FrontSide}}&lt;hr&gt;{{Back}}",
-  fields: { Front: "Question", Back: "Answer" },
-});
-
-console.log(result.question); // "Question"
-console.log(result.answer);   // "Question&lt;hr&gt;Answer"</code></pre>
-      </div>
-
-      <div class="api-section">
-        <h3>Cloze Deletions</h3>
-        <pre><code>const result = await renderCard({
-  front: "{{cloze:Text}}",
-  back: "{{cloze:Text}}",
-  fields: { Text: "{{c1::Paris}} is the capital of {{c2::France}}" },
-  cardOrdinal: 1,
-});
-
-// Card 1: "[...]" is visible, "France" is visible
-// Card 2: "Paris" is visible, "[...]" is visible</code></pre>
-      </div>
-
-      <div class="api-section">
-        <h3>Styled Cards</h3>
-        <pre><code>import { renderStyledCard, DEFAULT_ANKI_CSS } from 'anki-renderer';
-
-const result = await renderStyledCard({
-  front: "{{Front}}",
-  back: "{{Back}}",
-  fields: { Front: "Question", Back: "Answer" },
-  style: {
-    css: ".card { background: navy; color: white; }",
-    includeDefaultStyles: true,
-    nightMode: false,
-  },
-});
-
-// result.styledQuestion includes &lt;style&gt; tag and .card wrapper</code></pre>
+        <h3>Rendering Service</h3>
+        <p>Cards are rendered server-side by the official Anki engine. The HTTP API is public:</p>
+        <pre><code>curl -s https://anki-renderer.bjblabs.com/api/render \
+  -H 'Content-Type: application/json' -d '{
+    "templates": [{"front": "{{Front}}", "back": "{{FrontSide}}&lt;hr&gt;{{Back}}"}],
+    "fields": {"Front": "What is 2 + 2?", "Back": "4"}
+  }'</code></pre>
+        <p>The response contains one entry per card (or per cloze ordinal with
+        <code>"cloze": true</code>) with <code>question</code>/<code>answer</code> HTML exactly
+        as Anki produces it, plus the note type CSS and engine version.</p>
       </div>
 
       <div class="api-section">
@@ -186,9 +151,33 @@ const result = await renderStyledCard({
   template-back="{{Word}}&lt;br&gt;{{Definition}}"
   fields='{"Word": "hello", "Definition": "greeting"}'
   side="question"
-  default-styles
   night-mode&gt;
 &lt;/anki-card-preview&gt;</code></pre>
+        <p>Attributes: <code>template-front</code>, <code>template-back</code>, <code>fields</code>,
+        <code>side</code>, <code>cloze</code>, <code>card-ord</code>, <code>css</code>,
+        <code>night-mode</code>, <code>service-url</code>. Events:
+        <code>render-complete</code>, <code>render-error</code>.</p>
+      </div>
+
+      <div class="api-section">
+        <h3>Cloze Deletions</h3>
+        <pre><code>&lt;anki-card-preview
+  template-front="{{cloze:Text}}"
+  template-back="{{cloze:Text}}"
+  fields='{"Text": "{{c1::Paris}} is the capital of {{c2::France}}"}'
+  cloze
+  card-ord="0"&gt;
+&lt;/anki-card-preview&gt;
+
+&lt;!-- card-ord 0: "[...]" shown, "France" visible --&gt;
+&lt;!-- card-ord 1: "Paris" visible, "[...]" shown --&gt;</code></pre>
+      </div>
+
+      <div class="api-section">
+        <h3>Limitations</h3>
+        <p>Media files are not served: <code>&lt;img&gt;</code> tags in fields render as-is, so
+        images stored in Anki's media folder won't resolve. Audio/TTS tags display as a
+        ▶ placeholder without playback.</p>
       </div>
 
       <div class="api-section">
@@ -244,7 +233,8 @@ const result = await renderStyledCard({
   </main>
 
   <footer>
-    <p>Built with WASM for fast, client-side Anki card rendering.</p>
+    <p>Cards rendered by the official Anki engine via the anki-renderer service.</p>
+    <p id="engine-version">Checking rendering engine…</p>
     <p><a href="https://github.com/Gilbetrar/anki-renderer">View on GitHub</a></p>
   </footer>
 

--- a/demo/src/main.js
+++ b/demo/src/main.js
@@ -1,20 +1,15 @@
 /**
- * Demo site main script
+ * Demo site main script.
+ *
+ * Drives an <anki-card-preview> web component, which renders cards through
+ * the anki-renderer service (Anki's official engine) — no WASM involved.
  */
 
-// Dynamic import based on environment
-const isProduction = import.meta.env.PROD;
-const libPath = isProduction ? '/lib/index.js' : '../../dist/index.js';
+// Served from the repo's dist/ in dev (vite middleware) and from a copied
+// lib/ directory in production builds
+const componentPath = '/lib/component.js';
 
-let renderCard, initWasm, DEFAULT_ANKI_CSS, NIGHT_MODE_CSS;
-
-async function loadLibrary() {
-  const lib = await import(/* @vite-ignore */ libPath);
-  renderCard = lib.renderCard;
-  initWasm = lib.initWasm;
-  DEFAULT_ANKI_CSS = lib.DEFAULT_ANKI_CSS;
-  NIGHT_MODE_CSS = lib.NIGHT_MODE_CSS;
-}
+const SERVICE_URL = 'https://anki-renderer.bjblabs.com/api';
 
 // Example configurations
 const EXAMPLES = {
@@ -22,35 +17,40 @@ const EXAMPLES = {
     front: '{{Front}}',
     back: '{{FrontSide}}<hr>{{Back}}',
     fields: { Front: 'What is 2 + 2?', Back: '4' },
-    cardOrdinal: 0,
+    cloze: false,
+    cardOrd: 0,
     css: '',
   },
   cloze: {
     front: '{{cloze:Text}}',
     back: '{{cloze:Text}}',
     fields: { Text: '{{c1::Paris}} is the capital of {{c2::France}}' },
-    cardOrdinal: 1,
+    cloze: true,
+    cardOrd: 0,
     css: '',
   },
   hint: {
     front: 'What color is the sky?\n\n{{hint:Hint}}',
     back: '{{FrontSide}}<hr>{{Answer}}',
     fields: { Hint: 'Look up on a clear day', Answer: 'Blue' },
-    cardOrdinal: 0,
+    cloze: false,
+    cardOrd: 0,
     css: '',
   },
   furigana: {
     front: '{{furigana:Word}}',
     back: '{{furigana:Word}}<hr>{{Meaning}}',
     fields: { Word: '日本語[にほんご]', Meaning: 'Japanese language' },
-    cardOrdinal: 0,
+    cloze: false,
+    cardOrd: 0,
     css: '',
   },
   styled: {
     front: '{{Front}}',
     back: '{{FrontSide}}<hr>{{Back}}',
     fields: { Front: 'Styled card example', Back: 'With custom colors!' },
-    cardOrdinal: 0,
+    cloze: false,
+    cardOrd: 0,
     css: `.card {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
@@ -59,10 +59,22 @@ const EXAMPLES = {
 }`,
   },
   filters: {
-    front: 'HTML content: {{text:Content}}\n\nType your answer: {{type:Answer}}',
-    back: '{{FrontSide}}<hr>Correct: {{Answer}}',
-    fields: { Content: '<b>Bold</b> and <i>italic</i>', Answer: 'test' },
-    cardOrdinal: 0,
+    front: 'HTML content: {{text:Content}}',
+    back: '{{FrontSide}}<hr>{{Content}}',
+    fields: { Content: '<b>Bold</b> and <i>italic</i>' },
+    cloze: false,
+    cardOrd: 0,
+    css: '',
+  },
+  punctuated: {
+    front: '{{Source (book, article, etc.)}}',
+    back: '{{FrontSide}}<hr>{{Notes}}',
+    fields: {
+      'Source (book, article, etc.)': 'How to Take Smart Notes',
+      Notes: 'Field names with punctuation render fine — this broke the old WASM renderer (issue #20).',
+    },
+    cloze: false,
+    cardOrd: 0,
     css: '',
   },
 };
@@ -71,17 +83,17 @@ const EXAMPLES = {
 let templateFront;
 let templateBack;
 let fieldsJson;
-let cardOrdinal;
+let clozeCheckbox;
+let cardOrd;
 let nightMode;
-let defaultStyles;
 let customCss;
 let cardPreview;
 let previewContainer;
 let showQuestion;
 let showAnswer;
 
-let currentSide = 'question';
-let lastResult = null;
+/** The <anki-card-preview> element driving the preview */
+let preview;
 
 /**
  * Initialize the demo
@@ -91,35 +103,40 @@ async function init() {
   templateFront = document.getElementById('template-front');
   templateBack = document.getElementById('template-back');
   fieldsJson = document.getElementById('fields-json');
-  cardOrdinal = document.getElementById('card-ordinal');
+  clozeCheckbox = document.getElementById('cloze');
+  cardOrd = document.getElementById('card-ord');
   nightMode = document.getElementById('night-mode');
-  defaultStyles = document.getElementById('default-styles');
   customCss = document.getElementById('custom-css');
   cardPreview = document.getElementById('card-preview');
   previewContainer = document.getElementById('preview-container');
   showQuestion = document.getElementById('show-question');
   showAnswer = document.getElementById('show-answer');
 
-  // Load library and initialize WASM
+  // Load the web component (registers <anki-card-preview>)
   try {
-    cardPreview.innerHTML = '<div style="color: #666;">Loading library...</div>';
-    await loadLibrary();
-    await initWasm();
-    console.log('WASM initialized');
+    cardPreview.innerHTML = '<div style="color: #666;">Loading component...</div>';
+    await import(/* @vite-ignore */ componentPath);
   } catch (error) {
-    console.error('Failed to initialize:', error);
-    cardPreview.innerHTML = `<div style="color: red;">Failed to load renderer: ${error.message}</div>`;
+    console.error('Failed to load component:', error);
+    cardPreview.innerHTML = `<div style="color: red;">Failed to load component: ${error.message}</div>`;
     return;
   }
 
-  // Set up event listeners
-  templateFront.addEventListener('input', render);
-  templateBack.addEventListener('input', render);
-  fieldsJson.addEventListener('input', render);
-  cardOrdinal.addEventListener('input', render);
-  nightMode.addEventListener('change', render);
-  defaultStyles.addEventListener('change', render);
-  customCss.addEventListener('input', render);
+  // Create the preview element
+  preview = document.createElement('anki-card-preview');
+  preview.setAttribute('service-url', SERVICE_URL);
+  preview.setAttribute('side', 'question');
+  cardPreview.innerHTML = '';
+  cardPreview.appendChild(preview);
+
+  // Set up event listeners (the component debounces re-renders itself)
+  templateFront.addEventListener('input', syncPreview);
+  templateBack.addEventListener('input', syncPreview);
+  fieldsJson.addEventListener('input', syncPreview);
+  clozeCheckbox.addEventListener('change', syncPreview);
+  cardOrd.addEventListener('input', syncPreview);
+  nightMode.addEventListener('change', syncPreview);
+  customCss.addEventListener('input', syncPreview);
 
   showQuestion.addEventListener('click', () => setSide('question'));
   showAnswer.addEventListener('click', () => setSide('answer'));
@@ -131,18 +148,35 @@ async function init() {
     btn.addEventListener('click', () => loadExample(exampleKey));
   });
 
+  // Show the engine version in the footer
+  showEngineVersion();
+
   // Initial render
-  await render();
+  syncPreview();
+}
+
+/**
+ * Fetch the service health check and display the Anki engine version.
+ */
+async function showEngineVersion() {
+  const versionEl = document.getElementById('engine-version');
+  if (!versionEl) return;
+  try {
+    const res = await fetch(`${SERVICE_URL}/healthz`);
+    const data = await res.json();
+    versionEl.textContent = `Rendering engine: Anki ${data.ankiVersion}`;
+  } catch {
+    versionEl.textContent = 'Rendering service unreachable';
+  }
 }
 
 /**
  * Set which side to display
  */
 function setSide(side) {
-  currentSide = side;
   showQuestion.classList.toggle('active', side === 'question');
   showAnswer.classList.toggle('active', side === 'answer');
-  displayResult();
+  preview.setAttribute('side', side);
 }
 
 /**
@@ -155,72 +189,52 @@ function loadExample(key) {
   templateFront.value = example.front;
   templateBack.value = example.back;
   fieldsJson.value = JSON.stringify(example.fields, null, 2);
-  cardOrdinal.value = example.cardOrdinal;
+  clozeCheckbox.checked = example.cloze;
+  cardOrd.value = example.cardOrd;
   customCss.value = example.css;
 
-  render();
+  syncPreview();
 
   // Scroll to demo section
   document.getElementById('demo').scrollIntoView({ behavior: 'smooth' });
 }
 
 /**
- * Render the card preview
+ * Push the editor state onto the component's attributes.
  */
-async function render() {
-  // Parse fields
-  let fields;
+function syncPreview() {
+  // Validate fields JSON before handing it to the component
   try {
-    fields = JSON.parse(fieldsJson.value);
+    JSON.parse(fieldsJson.value);
+    fieldsJson.classList.remove('invalid');
   } catch {
-    cardPreview.innerHTML = '<div style="color: red;">Invalid JSON in fields</div>';
+    fieldsJson.classList.add('invalid');
     return;
   }
 
-  // Build options
-  const options = {
-    front: templateFront.value,
-    back: templateBack.value,
-    fields,
-    cardOrdinal: parseInt(cardOrdinal.value) || 0,
-  };
+  preview.setAttribute('template-front', templateFront.value);
+  preview.setAttribute('template-back', templateBack.value);
+  preview.setAttribute('fields', fieldsJson.value);
 
-  try {
-    lastResult = await renderCard(options);
-    displayResult();
-  } catch (error) {
-    cardPreview.innerHTML = `<div style="color: red;">Render error: ${error.message}</div>`;
+  if (clozeCheckbox.checked) {
+    preview.setAttribute('cloze', '');
+  } else {
+    preview.removeAttribute('cloze');
   }
-}
+  preview.setAttribute('card-ord', String(parseInt(cardOrd.value, 10) || 0));
 
-/**
- * Display the rendered result
- */
-function displayResult() {
-  if (!lastResult) return;
-
-  const content = currentSide === 'answer' ? lastResult.answer : lastResult.question;
-
-  // Build CSS
-  const cssParts = [];
-  if (defaultStyles.checked) {
-    cssParts.push(DEFAULT_ANKI_CSS);
-  }
-  if (nightMode.checked) {
-    cssParts.push(NIGHT_MODE_CSS);
-  }
   if (customCss.value) {
-    cssParts.push(customCss.value);
+    preview.setAttribute('css', customCss.value);
+  } else {
+    preview.removeAttribute('css');
   }
 
-  // Update container class for night mode
+  if (nightMode.checked) {
+    preview.setAttribute('night-mode', '');
+  } else {
+    preview.removeAttribute('night-mode');
+  }
   previewContainer.classList.toggle('night-mode', nightMode.checked);
-
-  // Create styled card wrapper
-  const cardClass = nightMode.checked ? 'card nightMode' : 'card';
-  const styleTag = cssParts.length ? `<style>${cssParts.join('\n')}</style>` : '';
-
-  cardPreview.innerHTML = `${styleTag}<div class="${cardClass}">${content}</div>`;
 }
 
 // Initialize when DOM is ready

--- a/demo/src/style.css
+++ b/demo/src/style.css
@@ -120,6 +120,11 @@ main {
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
 }
 
+.editor-group textarea.invalid {
+  border-color: #dc3545;
+  box-shadow: 0 0 0 3px rgba(220, 53, 69, 0.1);
+}
+
 .options-row {
   display: flex;
   gap: 1rem;

--- a/demo/vite.config.js
+++ b/demo/vite.config.js
@@ -6,6 +6,24 @@ import { copyFileSync, mkdirSync, existsSync, readdirSync, readFileSync, writeFi
 function copyAssetsPlugin() {
   return {
     name: 'copy-assets',
+    // In dev, serve the repo's dist/ at /lib/ so the demo uses the same
+    // import path as production builds
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (!req.url || !req.url.startsWith('/lib/')) return next();
+        const name = req.url.split('?')[0].slice('/lib/'.length);
+        const file = resolve(__dirname, '..', 'dist', name);
+        if (!name.includes('..') && existsSync(file)) {
+          res.setHeader(
+            'Content-Type',
+            name.endsWith('.js') ? 'application/javascript' : 'application/json'
+          );
+          res.end(readFileSync(file));
+        } else {
+          next();
+        }
+      });
+    },
     closeBundle() {
       const distOut = resolve(__dirname, 'dist');
       const pkgOut = resolve(distOut, 'pkg');

--- a/e2e/component.spec.ts
+++ b/e2e/component.spec.ts
@@ -1,120 +1,150 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+
+const SERVICE_URL = 'http://localhost:9003';
+
+/** Get the textContent of a card's shadow content container. */
+function contentText(page: Page, id: string) {
+  return page.evaluate((cardId) => {
+    const card = document.querySelector(`#${cardId}`);
+    return card?.shadowRoot?.querySelector('.content')?.textContent;
+  }, id);
+}
+
+/** Get the innerHTML of a card's shadow content container. */
+function contentHtml(page: Page, id: string) {
+  return page.evaluate((cardId) => {
+    const card = document.querySelector(`#${cardId}`);
+    return card?.shadowRoot?.querySelector('.content')?.innerHTML;
+  }, id);
+}
 
 test.describe('anki-card-preview component', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/e2e/test.html');
-    // Wait for WASM to initialize and first card to render
+    // Wait for all cards to finish their first render against the service
     await page.waitForFunction(() => {
-      const card = document.querySelector('#basic-question');
-      if (!card?.shadowRoot) return false;
-      const content = card.shadowRoot.querySelector('.content');
-      return content && !content.classList.contains('loading');
+      const cards = document.querySelectorAll('anki-card-preview');
+      return Array.from(cards).every((card) => {
+        const content = card.shadowRoot?.querySelector('.content');
+        return content && !content.classList.contains('loading');
+      });
     }, { timeout: 15000 });
   });
 
   test('renders basic card question side', async ({ page }) => {
-    const content = await page.evaluate(() => {
-      const card = document.querySelector('#basic-question');
-      return card?.shadowRoot?.querySelector('.content')?.textContent;
-    });
-
+    const content = await contentText(page, 'basic-question');
     expect(content).toContain('こんにちは');
     expect(content).not.toContain('Hello');
   });
 
-  test('renders basic card answer side', async ({ page }) => {
-    const content = await page.evaluate(() => {
-      const card = document.querySelector('#basic-answer');
-      return card?.shadowRoot?.querySelector('.content')?.textContent;
-    });
-
+  test('renders basic card answer side with FrontSide expansion', async ({ page }) => {
+    const content = await contentText(page, 'basic-answer');
     expect(content).toContain('こんにちは');
     expect(content).toContain('Hello');
   });
 
   test('renders cloze question side with hidden text', async ({ page }) => {
-    const content = await page.evaluate(() => {
-      const card = document.querySelector('#cloze-question');
-      return card?.shadowRoot?.querySelector('.content')?.textContent;
-    });
+    // c1 (Paris) should be hidden, c2 (France) visible
+    const text = await contentText(page, 'cloze-question');
+    expect(text).toContain('[...]');
+    expect(text).toContain('France');
+    expect(text).not.toContain('Paris');
 
-    // c1 (Paris) should be hidden
-    expect(content).toContain('[...]');
-    // c2 (France) should be visible
-    expect(content).toContain('France');
-    expect(content).not.toContain('Paris');
+    // Real Anki cloze markup: data-cloze/data-ordinal attributes
+    const html = await contentHtml(page, 'cloze-question');
+    expect(html).toContain('data-cloze');
+    expect(html).toContain('data-ordinal="1"');
   });
 
   test('renders cloze answer side with revealed text', async ({ page }) => {
-    const content = await page.evaluate(() => {
-      const card = document.querySelector('#cloze-answer');
-      return card?.shadowRoot?.querySelector('.content')?.innerHTML;
-    });
-
-    // Both should be visible in answer
-    expect(content).toContain('Paris');
-    expect(content).toContain('France');
-    // Cloze class should be present
-    expect(content).toContain('class="cloze"');
+    const html = await contentHtml(page, 'cloze-answer');
+    expect(html).toContain('Paris');
+    expect(html).toContain('France');
+    expect(html).toContain('class="cloze"');
   });
 
-  test('renders hint filter correctly', async ({ page }) => {
-    const content = await page.evaluate(() => {
-      const card = document.querySelector('#hint-card');
-      return card?.shadowRoot?.querySelector('.content')?.textContent;
-    });
+  test('card-ord selects the second cloze ordinal', async ({ page }) => {
+    // ord 1 = c2: France hidden, Paris visible
+    const text = await contentText(page, 'cloze-second');
+    expect(text).toContain('[...]');
+    expect(text).toContain('Paris');
+    expect(text).not.toContain('France');
+  });
 
-    expect(content).toContain('What is 2+2?');
-    // Hint should show clickable element
-    expect(content).toContain('Show');
+  test('renders hint filter as Anki does', async ({ page }) => {
+    const text = await contentText(page, 'hint-card');
+    expect(text).toContain('What is 2+2?');
+    // Anki renders a clickable link named after the field
+    expect(text).toContain('Hint');
+    const html = await contentHtml(page, 'hint-card');
+    expect(html).toContain('class="hint"');
+  });
+
+  test('renders punctuation-heavy field names (issue #20)', async ({ page }) => {
+    // The old WASM path threw a parse error on this field name
+    const content = await contentText(page, 'punctuated-card');
+    expect(content).toContain('How to Take Smart Notes');
+
+    const isError = await page.evaluate(() => {
+      const card = document.querySelector('#punctuated-card');
+      return card?.shadowRoot
+        ?.querySelector('.content')
+        ?.classList.contains('error');
+    });
+    expect(isError).toBe(false);
+  });
+
+  test('replaces audio markers with a placeholder', async ({ page }) => {
+    const text = await contentText(page, 'audio-card');
+    expect(text).toContain('Listen:');
+    expect(text).toContain('▶');
+    expect(text).not.toContain('[anki:play');
+  });
+
+  test('injects the note type CSS from the service', async ({ page }) => {
+    const styles = await page.evaluate(() => {
+      const card = document.querySelector('#basic-question');
+      return Array.from(card?.shadowRoot?.querySelectorAll('style') ?? [])
+        .map((s) => s.textContent)
+        .join('\n');
+    });
+    // Anki's stock .card css is returned when no custom css is sent
+    expect(styles).toContain('.card {');
+    expect(styles).toContain('font-family: arial');
   });
 
   test('updates dynamically when attributes change', async ({ page }) => {
-    // Initial content
-    const initialContent = await page.evaluate(() => {
-      const card = document.querySelector('#dynamic-card');
-      return card?.shadowRoot?.querySelector('.content')?.textContent;
-    });
+    const initialContent = await contentText(page, 'dynamic-card');
     expect(initialContent).toContain('Initial question');
 
-    // Click update button
     await page.click('#update-card');
 
-    // Wait for re-render
     await page.waitForFunction(() => {
       const card = document.querySelector('#dynamic-card');
       const content = card?.shadowRoot?.querySelector('.content')?.textContent;
       return content?.includes('Updated question!');
     }, { timeout: 5000 });
 
-    const updatedContent = await page.evaluate(() => {
-      const card = document.querySelector('#dynamic-card');
-      return card?.shadowRoot?.querySelector('.content')?.textContent;
-    });
+    const updatedContent = await contentText(page, 'dynamic-card');
     expect(updatedContent).toContain('Updated question!');
   });
 
   test('uses Shadow DOM for style isolation', async ({ page }) => {
-    // Verify shadow root exists
     const hasShadowRoot = await page.evaluate(() => {
       const card = document.querySelector('#basic-question');
       return card?.shadowRoot !== null;
     });
     expect(hasShadowRoot).toBe(true);
 
-    // Verify content is inside shadow DOM
-    const shadowContent = await page.evaluate(() => {
-      const card = document.querySelector('#basic-question');
-      return card?.shadowRoot?.querySelector('.content')?.textContent;
-    });
+    const shadowContent = await contentText(page, 'basic-question');
     expect(shadowContent).toContain('こんにちは');
   });
 
-  test('emits render-complete event', async ({ page }) => {
-    // Create a new card and listen for events
-    const eventFired = await page.evaluate(async () => {
+  test('emits render-complete event with card details', async ({ page }) => {
+    const eventDetail = await page.evaluate(async (serviceUrl) => {
       return new Promise((resolve) => {
         const card = document.createElement('anki-card-preview');
+        card.setAttribute('service-url', serviceUrl);
         card.setAttribute('template-front', '{{Test}}');
         card.setAttribute('template-back', '{{Test}}');
         card.setAttribute('fields', JSON.stringify({ Test: 'Event test' }));
@@ -125,35 +155,77 @@ test.describe('anki-card-preview component', () => {
           resolve({
             content: detail.content,
             side: detail.side,
+            cardOrd: detail.card.ord,
+            cardCount: detail.cards.length,
+            hasVersion: typeof detail.ankiVersion === 'string' && detail.ankiVersion.length > 0,
           });
         });
 
         document.body.appendChild(card);
       });
-    });
+    }, SERVICE_URL);
 
-    expect(eventFired).toEqual({
+    expect(eventDetail).toEqual({
       content: 'Event test',
       side: 'question',
+      cardOrd: 0,
+      cardCount: 1,
+      hasVersion: true,
     });
+  });
+
+  test('emits render-error on template errors with Anki message', async ({ page }) => {
+    const errorDetail = await page.evaluate(async (serviceUrl) => {
+      return new Promise<string>((resolve) => {
+        const card = document.createElement('anki-card-preview');
+        card.setAttribute('service-url', serviceUrl);
+        card.setAttribute('template-front', '{{#Unclosed}}oops');
+        card.setAttribute('template-back', '{{Front}}');
+        card.setAttribute('fields', JSON.stringify({ Front: 'Q' }));
+
+        card.addEventListener('render-error', (e: Event) => {
+          resolve((e as CustomEvent).detail.message);
+        });
+
+        document.body.appendChild(card);
+      });
+    }, SERVICE_URL);
+
+    expect(errorDetail.length).toBeGreaterThan(0);
   });
 
   test('supports programmatic property access', async ({ page }) => {
     const cardProperties = await page.evaluate(() => {
-      const card = document.querySelector('#basic-question') as any;
+      const card = document.querySelector('#cloze-second') as any;
       return {
         templateFront: card.templateFront,
-        templateBack: card.templateBack,
-        fields: card.fields,
         side: card.side,
-        cardOrdinal: card.cardOrdinal,
+        cloze: card.cloze,
+        cardOrd: card.cardOrd,
+        serviceUrl: card.serviceUrl,
       };
     });
 
-    expect(cardProperties.templateFront).toBe('{{Word}}');
-    expect(cardProperties.templateBack).toBe('{{Word}}<br>{{Definition}}');
-    expect(cardProperties.fields).toEqual({ Word: 'こんにちは', Definition: 'Hello' });
+    expect(cardProperties.templateFront).toBe('{{cloze:Text}}');
     expect(cardProperties.side).toBe('question');
-    expect(cardProperties.cardOrdinal).toBe(0);
+    expect(cardProperties.cloze).toBe(true);
+    expect(cardProperties.cardOrd).toBe(1);
+    expect(cardProperties.serviceUrl).toBe(SERVICE_URL);
+  });
+
+  test('does not load any WASM in the component bundle', async ({ page }) => {
+    const wasmRequests: string[] = [];
+    page.on('request', (req) => {
+      if (req.url().includes('.wasm') || req.url().includes('pkg/')) {
+        wasmRequests.push(req.url());
+      }
+    });
+    await page.reload();
+    await page.waitForFunction(() => {
+      const card = document.querySelector('#basic-question');
+      const content = card?.shadowRoot?.querySelector('.content');
+      return content && !content.classList.contains('loading');
+    }, { timeout: 15000 });
+    expect(wasmRequests).toEqual([]);
   });
 });

--- a/e2e/test.html
+++ b/e2e/test.html
@@ -35,11 +35,13 @@
 </head>
 <body>
   <h1>Anki Card Preview Component Tests</h1>
+  <p>These cards render against a local rendering service at <code>localhost:9003</code>.</p>
 
   <div class="test-card">
     <h3>Basic Card - Question Side</h3>
     <anki-card-preview
       id="basic-question"
+      service-url="http://localhost:9003"
       template-front="{{Word}}"
       template-back="{{Word}}<br>{{Definition}}"
       fields='{"Word": "こんにちは", "Definition": "Hello"}'
@@ -51,6 +53,7 @@
     <h3>Basic Card - Answer Side</h3>
     <anki-card-preview
       id="basic-answer"
+      service-url="http://localhost:9003"
       template-front="{{Word}}"
       template-back="{{FrontSide}}<hr>{{Definition}}"
       fields='{"Word": "こんにちは", "Definition": "Hello"}'
@@ -59,26 +62,44 @@
   </div>
 
   <div class="test-card">
-    <h3>Cloze Card - Question Side</h3>
+    <h3>Cloze Card - Question Side (c1, ord 0)</h3>
     <anki-card-preview
       id="cloze-question"
+      service-url="http://localhost:9003"
       template-front="{{cloze:Text}}"
       template-back="{{cloze:Text}}"
       fields='{"Text": "{{c1::Paris}} is the capital of {{c2::France}}"}'
-      card-ordinal="1"
+      cloze
+      card-ord="0"
       side="question">
     </anki-card-preview>
   </div>
 
   <div class="test-card">
-    <h3>Cloze Card - Answer Side</h3>
+    <h3>Cloze Card - Answer Side (c1, ord 0)</h3>
     <anki-card-preview
       id="cloze-answer"
+      service-url="http://localhost:9003"
       template-front="{{cloze:Text}}"
       template-back="{{cloze:Text}}"
       fields='{"Text": "{{c1::Paris}} is the capital of {{c2::France}}"}'
-      card-ordinal="1"
+      cloze
+      card-ord="0"
       side="answer">
+    </anki-card-preview>
+  </div>
+
+  <div class="test-card">
+    <h3>Cloze Card - Second Ordinal (c2, ord 1)</h3>
+    <anki-card-preview
+      id="cloze-second"
+      service-url="http://localhost:9003"
+      template-front="{{cloze:Text}}"
+      template-back="{{cloze:Text}}"
+      fields='{"Text": "{{c1::Paris}} is the capital of {{c2::France}}"}'
+      cloze
+      card-ord="1"
+      side="question">
     </anki-card-preview>
   </div>
 
@@ -86,6 +107,7 @@
     <h3>With Hint Filter</h3>
     <anki-card-preview
       id="hint-card"
+      service-url="http://localhost:9003"
       template-front="What is 2+2? {{hint:Hint}}"
       template-back="{{FrontSide}}<hr>{{Answer}}"
       fields='{"Hint": "Think of counting fingers", "Answer": "4"}'
@@ -94,9 +116,34 @@
   </div>
 
   <div class="test-card">
+    <h3>Punctuated Field Name (issue #20 reproduction)</h3>
+    <anki-card-preview
+      id="punctuated-card"
+      service-url="http://localhost:9003"
+      template-front="{{Source (book, article, etc.)}}"
+      template-back="{{FrontSide}}<hr>{{Notes}}"
+      fields='{"Source (book, article, etc.)": "How to Take Smart Notes", "Notes": "Write it down"}'
+      side="question">
+    </anki-card-preview>
+  </div>
+
+  <div class="test-card">
+    <h3>Audio Field (placeholder, no playback)</h3>
+    <anki-card-preview
+      id="audio-card"
+      service-url="http://localhost:9003"
+      template-front="Listen: {{Audio}}"
+      template-back="{{Audio}}"
+      fields='{"Audio": "[sound:test.mp3]"}'
+      side="question">
+    </anki-card-preview>
+  </div>
+
+  <div class="test-card">
     <h3>Dynamic Card (for programmatic updates)</h3>
     <anki-card-preview
       id="dynamic-card"
+      service-url="http://localhost:9003"
       template-front="{{Front}}"
       template-back="{{Back}}"
       fields='{"Front": "Initial question", "Back": "Initial answer"}'

--- a/js/src/component.ts
+++ b/js/src/component.ts
@@ -2,6 +2,8 @@
  * Anki Card Preview Web Component
  *
  * A custom element for rendering Anki card previews with Shadow DOM isolation.
+ * Rendering is delegated to the anki-renderer service, which wraps the
+ * official Anki engine — output HTML is exactly what Anki desktop produces.
  *
  * @example
  * ```html
@@ -14,17 +16,74 @@
  * ```
  */
 
-import { renderCard, initWasm, DEFAULT_ANKI_CSS, NIGHT_MODE_CSS } from './index.js';
+import { NIGHT_MODE_CSS } from './styles.js';
 import type { NoteFields } from './types.js';
+
+/**
+ * Default rendering service endpoint.
+ */
+export const DEFAULT_SERVICE_URL = 'https://anki-renderer.bjblabs.com/api';
+
+/**
+ * How long attribute changes are coalesced before re-rendering (ms).
+ */
+const RENDER_DEBOUNCE_MS = 50;
+
+/**
+ * An audio/TTS tag extracted by the service from `[sound:...]` / `{{tts ...}}`.
+ */
+export interface AvTag {
+  kind: 'sound' | 'tts';
+  filename?: string;
+  fieldText?: string;
+  lang?: string;
+  voices?: string[];
+  speed?: number;
+}
+
+/**
+ * One rendered card from the service (one per template, or one per cloze
+ * ordinal for cloze note types).
+ */
+export interface RenderedCard {
+  /** Card ordinal (0-indexed; cloze ordinal for cloze note types) */
+  ord: number;
+  /** Template name */
+  name: string;
+  /** True if Anki would not generate this card (front renders empty) */
+  empty: boolean;
+  /** Question HTML, exactly as Anki produces it */
+  question: string;
+  /** Answer HTML, exactly as Anki produces it */
+  answer: string;
+  questionAvTags: AvTag[];
+  answerAvTags: AvTag[];
+}
+
+/**
+ * Response from the rendering service's POST /render endpoint.
+ */
+export interface ServiceRenderResponse {
+  cards: RenderedCard[];
+  /** Note type CSS (the request css, or Anki's stock .card css) */
+  css: string;
+  ankiVersion: string;
+}
 
 /**
  * Event detail for render-complete event
  */
 export interface RenderCompleteDetail {
-  /** The rendered HTML content */
+  /** The rendered HTML content (after audio markers are replaced) */
   content: string;
   /** Which side was rendered */
   side: 'question' | 'answer';
+  /** The card that was displayed */
+  card: RenderedCard;
+  /** All cards returned by the service */
+  cards: RenderedCard[];
+  /** Version of the Anki engine that rendered the card */
+  ankiVersion: string;
 }
 
 /**
@@ -45,10 +104,12 @@ export interface RenderErrorDetail {
  * - `template-back`: Template for the answer side
  * - `fields`: JSON object of field name/value pairs
  * - `side`: Which side to display ("question" or "answer")
- * - `card-ordinal`: Card ordinal for cloze cards (1-indexed, optional)
- * - `css`: Custom CSS to apply to the card
+ * - `cloze`: Treat the note type as cloze - boolean attribute
+ * - `card-ord`: Which card to display, by 0-indexed ordinal (for cloze, one
+ *   card exists per cloze ordinal). Defaults to the first non-empty card.
+ * - `css`: Note type CSS (replaces Anki's stock .card css, as in Anki)
  * - `night-mode`: Enable night mode (dark theme) - boolean attribute
- * - `default-styles`: Include Anki's default styles - boolean attribute
+ * - `service-url`: Base URL of the rendering service
  *
  * Events:
  * - `render-complete`: Fired when rendering succeeds
@@ -57,12 +118,24 @@ export interface RenderErrorDetail {
 export class AnkiCardPreview extends HTMLElement {
   private shadow: ShadowRoot;
   private baseStyleElement: HTMLStyleElement;
-  private customStyleElement: HTMLStyleElement;
+  private cardStyleElement: HTMLStyleElement;
   private contentContainer: HTMLDivElement;
   private initialized = false;
+  private renderTimer: ReturnType<typeof setTimeout> | null = null;
+  private renderSeq = 0;
 
   static get observedAttributes(): string[] {
-    return ['template-front', 'template-back', 'fields', 'side', 'card-ordinal', 'css', 'night-mode', 'default-styles'];
+    return [
+      'template-front',
+      'template-back',
+      'fields',
+      'side',
+      'cloze',
+      'card-ord',
+      'css',
+      'night-mode',
+      'service-url',
+    ];
   }
 
   constructor() {
@@ -93,21 +166,15 @@ export class AnkiCardPreview extends HTMLElement {
         color: #6c757d;
         font-style: italic;
       }
-      /* Fallback styles if no custom CSS is provided */
-      .cloze {
-        font-weight: bold;
-        color: #0000ff;
-      }
-      .hint {
-        background-color: #ffffcc;
-        padding: 2px 4px;
-        border-radius: 2px;
-        cursor: pointer;
+      .replay-button {
+        display: inline-block;
+        cursor: default;
+        color: #0a5;
       }
     `;
 
-    // Custom style element for user CSS, default styles, night mode
-    this.customStyleElement = document.createElement('style');
+    // Style element for the note type CSS returned by the service
+    this.cardStyleElement = document.createElement('style');
 
     // Create content container (with .card class for CSS targeting)
     this.contentContainer = document.createElement('div');
@@ -115,17 +182,21 @@ export class AnkiCardPreview extends HTMLElement {
     this.contentContainer.textContent = 'Loading...';
 
     this.shadow.appendChild(this.baseStyleElement);
-    this.shadow.appendChild(this.customStyleElement);
+    this.shadow.appendChild(this.cardStyleElement);
     this.shadow.appendChild(this.contentContainer);
   }
 
   connectedCallback(): void {
     this.initialized = true;
-    this.render();
+    this.scheduleRender();
   }
 
   disconnectedCallback(): void {
     this.initialized = false;
+    if (this.renderTimer !== null) {
+      clearTimeout(this.renderTimer);
+      this.renderTimer = null;
+    }
   }
 
   attributeChangedCallback(
@@ -134,9 +205,9 @@ export class AnkiCardPreview extends HTMLElement {
     _newValue: string | null
   ): void {
     if (this.initialized) {
-      this.render();
+      this.scheduleRender();
     }
-    // If not initialized, render() will be called in connectedCallback
+    // If not initialized, render is scheduled in connectedCallback
   }
 
   /**
@@ -191,19 +262,41 @@ export class AnkiCardPreview extends HTMLElement {
   }
 
   /**
-   * Get the card ordinal for cloze cards (1-indexed, 0 for non-cloze)
+   * Get whether the note type is treated as cloze
    */
-  get cardOrdinal(): number {
-    const ordinal = parseInt(this.getAttribute('card-ordinal') || '0', 10);
-    return isNaN(ordinal) ? 0 : ordinal;
+  get cloze(): boolean {
+    return this.hasAttribute('cloze');
   }
 
-  set cardOrdinal(value: number) {
-    this.setAttribute('card-ordinal', String(value));
+  set cloze(value: boolean) {
+    if (value) {
+      this.setAttribute('cloze', '');
+    } else {
+      this.removeAttribute('cloze');
+    }
   }
 
   /**
-   * Get custom CSS for the card
+   * Get the card ordinal to display (0-indexed), or null to auto-pick
+   * the first non-empty card.
+   */
+  get cardOrd(): number | null {
+    const attr = this.getAttribute('card-ord');
+    if (attr === null || attr === '') return null;
+    const ord = parseInt(attr, 10);
+    return isNaN(ord) ? null : ord;
+  }
+
+  set cardOrd(value: number | null) {
+    if (value === null) {
+      this.removeAttribute('card-ord');
+    } else {
+      this.setAttribute('card-ord', String(value));
+    }
+  }
+
+  /**
+   * Get the note type CSS for the card
    */
   get css(): string {
     return this.getAttribute('css') || '';
@@ -229,82 +322,135 @@ export class AnkiCardPreview extends HTMLElement {
   }
 
   /**
-   * Get whether default Anki styles should be included
+   * Get the rendering service base URL
    */
-  get defaultStyles(): boolean {
-    return this.hasAttribute('default-styles');
+  get serviceUrl(): string {
+    const url = this.getAttribute('service-url') || DEFAULT_SERVICE_URL;
+    return url.replace(/\/+$/, '');
   }
 
-  set defaultStyles(value: boolean) {
-    if (value) {
-      this.setAttribute('default-styles', '');
-    } else {
-      this.removeAttribute('default-styles');
-    }
+  set serviceUrl(value: string) {
+    this.setAttribute('service-url', value);
   }
 
   /**
-   * Build the combined CSS for the card
+   * Schedule a debounced render. Multiple attribute changes within the
+   * debounce window result in a single service call.
    */
-  private buildCardCss(): string {
-    const parts: string[] = [];
-
-    if (this.defaultStyles) {
-      parts.push(DEFAULT_ANKI_CSS);
+  private scheduleRender(): void {
+    if (this.renderTimer !== null) {
+      clearTimeout(this.renderTimer);
     }
-
-    if (this.nightMode) {
-      parts.push(NIGHT_MODE_CSS);
-    }
-
-    if (this.css) {
-      parts.push(this.css);
-    }
-
-    return parts.join('\n');
+    this.renderTimer = setTimeout(() => {
+      this.renderTimer = null;
+      void this.render();
+    }, RENDER_DEBOUNCE_MS);
   }
 
   /**
-   * Programmatically trigger a re-render
+   * Replace Anki's `[anki:play:q:0]` audio markers with a ▶ placeholder
+   * (display-accurate; no playback).
+   */
+  private static replaceAvMarkers(html: string): string {
+    return html.replace(
+      /\[anki:play:[qa]:\d+\]/g,
+      '<span class="replay-button" title="Audio">▶</span>'
+    );
+  }
+
+  /**
+   * Pick which card to display: explicit card-ord if set, otherwise the
+   * first card Anki would actually generate, otherwise the first card.
+   */
+  private pickCard(cards: RenderedCard[]): RenderedCard {
+    const ord = this.cardOrd;
+    if (ord !== null) {
+      const match = cards.find((c) => c.ord === ord);
+      if (!match) {
+        throw new Error(
+          `no card with ordinal ${ord} (got: ${cards.map((c) => c.ord).join(', ')})`
+        );
+      }
+      return match;
+    }
+    return cards.find((c) => !c.empty) || cards[0];
+  }
+
+  /**
+   * Programmatically trigger a re-render (calls the rendering service).
    */
   async render(): Promise<void> {
     if (!this.initialized) {
-      // Will be called again from connectedCallback
+      // Will be scheduled again from connectedCallback
       return;
     }
 
-    const front = this.templateFront;
-    const back = this.templateBack;
-    const fields = this.fields;
+    const seq = ++this.renderSeq;
     const side = this.side;
-    const cardOrdinal = this.cardOrdinal;
-
-    // Update custom CSS
-    this.customStyleElement.textContent = this.buildCardCss();
 
     // Show loading state
     this.contentContainer.className = 'content card loading';
     this.contentContainer.textContent = 'Loading...';
 
     try {
-      // Ensure WASM is initialized
-      await initWasm();
+      const fields = this.fields;
+      if (Object.keys(fields).length === 0) {
+        throw new Error('fields attribute must be a JSON object with at least one field');
+      }
 
-      // Render the card
-      const result = await renderCard({
-        front,
-        back,
+      const body: Record<string, unknown> = {
+        templates: [
+          { front: this.templateFront, back: this.templateBack, name: 'Card 1' },
+        ],
         fields,
-        cardOrdinal,
+        cloze: this.cloze,
+      };
+      if (this.css) {
+        body.css = this.css;
+      }
+
+      const response = await fetch(`${this.serviceUrl}/render`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
       });
 
-      // Display the requested side
-      const content = side === 'answer' ? result.answer : result.question;
+      if (!response.ok) {
+        let detail = `service responded with ${response.status}`;
+        try {
+          const errBody = await response.json();
+          if (typeof errBody.detail === 'string') {
+            detail = errBody.detail;
+          } else if (errBody.detail) {
+            detail = JSON.stringify(errBody.detail);
+          }
+        } catch {
+          // Keep the status-based message
+        }
+        throw new Error(detail);
+      }
 
-      // Set classes including nightMode if enabled
+      const data: ServiceRenderResponse = await response.json();
+
+      // A newer render started while this one was in flight — drop it
+      if (seq !== this.renderSeq) {
+        return;
+      }
+
+      const card = this.pickCard(data.cards);
+      const raw = side === 'answer' ? card.answer : card.question;
+      const content = AnkiCardPreview.replaceAvMarkers(raw);
+
+      // Inject the note type CSS so it applies as in Anki; night mode
+      // overrides come after so they win the cascade
+      this.cardStyleElement.textContent = this.nightMode
+        ? `${data.css}\n${NIGHT_MODE_CSS}`
+        : data.css;
+
+      // Standard Anki classes so note type CSS applies as in Anki
       const classes = ['content', 'card'];
       if (this.nightMode) {
-        classes.push('nightMode');
+        classes.push('night_mode', 'nightMode');
       }
       this.contentContainer.className = classes.join(' ');
       this.contentContainer.innerHTML = content;
@@ -312,12 +458,15 @@ export class AnkiCardPreview extends HTMLElement {
       // Dispatch success event
       this.dispatchEvent(
         new CustomEvent<RenderCompleteDetail>('render-complete', {
-          detail: { content, side },
+          detail: { content, side, card, cards: data.cards, ankiVersion: data.ankiVersion },
           bubbles: true,
           composed: true,
         })
       );
     } catch (error) {
+      if (seq !== this.renderSeq) {
+        return;
+      }
       const message = error instanceof Error ? error.message : String(error);
 
       this.contentContainer.className = 'content card error';

--- a/js/tests/component.test.ts
+++ b/js/tests/component.test.ts
@@ -1,16 +1,103 @@
 /**
- * Tests for AnkiCardPreview web component exports
+ * Tests for the AnkiCardPreview web component.
  *
- * Note: Full browser testing with Playwright is in e2e/component.spec.ts.
- * These tests verify the module exports are correct and the class is valid.
+ * The component calls the rendering service over HTTP, so these tests mock
+ * global fetch and exercise the full render flow in jsdom. Browser tests
+ * against a real service instance are in e2e/component.spec.ts.
  *
  * @jest-environment jsdom
  */
 
-import { AnkiCardPreview, registerComponent } from '../src/component.js';
-import type { RenderCompleteDetail, RenderErrorDetail } from '../src/component.js';
+import { jest } from '@jest/globals';
+import {
+  AnkiCardPreview,
+  registerComponent,
+  DEFAULT_SERVICE_URL,
+} from '../src/component.js';
+import type {
+  RenderCompleteDetail,
+  RenderErrorDetail,
+  ServiceRenderResponse,
+  RenderedCard,
+} from '../src/component.js';
+
+function makeCard(overrides: Partial<RenderedCard> = {}): RenderedCard {
+  return {
+    ord: 0,
+    name: 'Card 1',
+    empty: false,
+    question: 'Question HTML',
+    answer: 'Answer HTML',
+    questionAvTags: [],
+    answerAvTags: [],
+    ...overrides,
+  };
+}
+
+function makeResponse(overrides: Partial<ServiceRenderResponse> = {}): ServiceRenderResponse {
+  return {
+    cards: [makeCard()],
+    css: '.card { color: black; }',
+    ankiVersion: '25.09.4',
+    ...overrides,
+  };
+}
+
+function mockFetchOk(data: ServiceRenderResponse): jest.Mock {
+  const mock = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(data),
+    })
+  );
+  (globalThis as Record<string, unknown>).fetch = mock;
+  return mock;
+}
+
+function mockFetchError(status: number, body: unknown): jest.Mock {
+  const mock = jest.fn(() =>
+    Promise.resolve({
+      ok: false,
+      status,
+      json: () => Promise.resolve(body),
+    })
+  );
+  (globalThis as Record<string, unknown>).fetch = mock;
+  return mock;
+}
+
+function createPreview(attrs: Record<string, string>): AnkiCardPreview {
+  const el = document.createElement('anki-card-preview') as AnkiCardPreview;
+  for (const [name, value] of Object.entries(attrs)) {
+    el.setAttribute(name, value);
+  }
+  return el;
+}
+
+function waitForEvent<T>(el: HTMLElement, type: string, timeoutMs = 2000): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`timed out waiting for ${type}`)),
+      timeoutMs
+    );
+    el.addEventListener(
+      type,
+      (e) => {
+        clearTimeout(timer);
+        resolve((e as CustomEvent<T>).detail);
+      },
+      { once: true }
+    );
+  });
+}
 
 describe('AnkiCardPreview', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    delete (globalThis as Record<string, unknown>).fetch;
+  });
+
   describe('exports', () => {
     it('should export AnkiCardPreview class', () => {
       expect(AnkiCardPreview).toBeDefined();
@@ -23,8 +110,6 @@ describe('AnkiCardPreview', () => {
     });
 
     it('should have correct class prototype', () => {
-      expect(AnkiCardPreview.prototype).toBeDefined();
-      // Check that it has the expected methods
       expect(typeof AnkiCardPreview.prototype.render).toBe('function');
       expect(typeof AnkiCardPreview.prototype.connectedCallback).toBe('function');
       expect(typeof AnkiCardPreview.prototype.disconnectedCallback).toBe('function');
@@ -37,28 +122,294 @@ describe('AnkiCardPreview', () => {
         'template-back',
         'fields',
         'side',
-        'card-ordinal',
+        'cloze',
+        'card-ord',
         'css',
         'night-mode',
-        'default-styles',
+        'service-url',
       ]);
     });
   });
 
-  describe('type exports', () => {
-    it('should allow creating typed event details', () => {
-      // These are compile-time checks - if they compile, types are correct
-      const completeDetail: RenderCompleteDetail = {
-        content: '<b>test</b>',
-        side: 'question',
-      };
-      expect(completeDetail.content).toBe('<b>test</b>');
+  describe('rendering via the service', () => {
+    it('POSTs templates and fields to the default service URL', async () => {
+      const fetchMock = mockFetchOk(makeResponse());
+      const el = createPreview({
+        'template-front': '{{Front}}',
+        'template-back': '{{FrontSide}}<hr>{{Back}}',
+        fields: JSON.stringify({ Front: 'Q', Back: 'A' }),
+      });
+      const done = waitForEvent<RenderCompleteDetail>(el, 'render-complete');
+      document.body.appendChild(el);
+      await done;
 
-      const errorDetail: RenderErrorDetail = {
-        message: 'test error',
-        error: new Error('test'),
-      };
-      expect(errorDetail.message).toBe('test error');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(`${DEFAULT_SERVICE_URL}/render`);
+      expect(init.method).toBe('POST');
+      expect(JSON.parse(init.body as string)).toEqual({
+        templates: [{ front: '{{Front}}', back: '{{FrontSide}}<hr>{{Back}}', name: 'Card 1' }],
+        fields: { Front: 'Q', Back: 'A' },
+        cloze: false,
+      });
+    });
+
+    it('displays the question side and injects the service CSS', async () => {
+      mockFetchOk(
+        makeResponse({
+          cards: [makeCard({ question: '<b>Bonjour</b>', answer: 'Bonjour<hr>Hello' })],
+          css: '.card { background: navy; }',
+        })
+      );
+      const el = createPreview({
+        'template-front': '{{Front}}',
+        'template-back': '{{FrontSide}}<hr>{{Back}}',
+        fields: JSON.stringify({ Front: 'Bonjour', Back: 'Hello' }),
+        side: 'question',
+      });
+      const done = waitForEvent<RenderCompleteDetail>(el, 'render-complete');
+      document.body.appendChild(el);
+      const detail = await done;
+
+      expect(detail.content).toBe('<b>Bonjour</b>');
+      expect(detail.side).toBe('question');
+      expect(detail.ankiVersion).toBe('25.09.4');
+      const content = el.shadowRoot!.querySelector('.content')!;
+      expect(content.innerHTML).toBe('<b>Bonjour</b>');
+      expect(content.classList.contains('card')).toBe(true);
+      const styles = Array.from(el.shadowRoot!.querySelectorAll('style'))
+        .map((s) => s.textContent)
+        .join('\n');
+      expect(styles).toContain('background: navy');
+    });
+
+    it('displays the answer side when side="answer"', async () => {
+      mockFetchOk(
+        makeResponse({ cards: [makeCard({ question: 'Q side', answer: 'A side' })] })
+      );
+      const el = createPreview({
+        'template-front': '{{Front}}',
+        'template-back': '{{Back}}',
+        fields: JSON.stringify({ Front: 'Q', Back: 'A' }),
+        side: 'answer',
+      });
+      const done = waitForEvent<RenderCompleteDetail>(el, 'render-complete');
+      document.body.appendChild(el);
+      const detail = await done;
+
+      expect(detail.content).toBe('A side');
+      expect(el.shadowRoot!.querySelector('.content')!.textContent).toBe('A side');
+    });
+
+    it('sends cloze=true and picks the card matching card-ord', async () => {
+      const fetchMock = mockFetchOk(
+        makeResponse({
+          cards: [
+            makeCard({ ord: 0, question: 'card zero' }),
+            makeCard({ ord: 1, question: 'card one' }),
+          ],
+        })
+      );
+      const el = createPreview({
+        'template-front': '{{cloze:Text}}',
+        'template-back': '{{cloze:Text}}',
+        fields: JSON.stringify({ Text: '{{c1::a}} {{c2::b}}' }),
+        cloze: '',
+        'card-ord': '1',
+      });
+      const done = waitForEvent<RenderCompleteDetail>(el, 'render-complete');
+      document.body.appendChild(el);
+      const detail = await done;
+
+      const body = JSON.parse(
+        (fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string
+      );
+      expect(body.cloze).toBe(true);
+      expect(detail.content).toBe('card one');
+      expect(detail.card.ord).toBe(1);
+      expect(detail.cards).toHaveLength(2);
+    });
+
+    it('defaults to the first non-empty card when card-ord is not set', async () => {
+      mockFetchOk(
+        makeResponse({
+          cards: [
+            makeCard({ ord: 0, empty: true, question: 'empty card' }),
+            makeCard({ ord: 1, question: 'real card' }),
+          ],
+        })
+      );
+      const el = createPreview({
+        'template-front': '{{#Extra}}{{Front}}{{/Extra}}',
+        'template-back': '{{Back}}',
+        fields: JSON.stringify({ Front: 'Q', Back: 'A', Extra: '' }),
+      });
+      const done = waitForEvent<RenderCompleteDetail>(el, 'render-complete');
+      document.body.appendChild(el);
+      const detail = await done;
+
+      expect(detail.content).toBe('real card');
+    });
+
+    it('replaces [anki:play:...] audio markers with a placeholder', async () => {
+      mockFetchOk(
+        makeResponse({
+          cards: [
+            makeCard({
+              question: 'Listen: [anki:play:q:0]',
+              questionAvTags: [{ kind: 'sound', filename: 'audio.mp3' }],
+            }),
+          ],
+        })
+      );
+      const el = createPreview({
+        'template-front': '{{Audio}}',
+        'template-back': '{{Audio}}',
+        fields: JSON.stringify({ Audio: '[sound:audio.mp3]' }),
+      });
+      const done = waitForEvent<RenderCompleteDetail>(el, 'render-complete');
+      document.body.appendChild(el);
+      const detail = await done;
+
+      expect(detail.content).not.toContain('[anki:play');
+      expect(detail.content).toContain('▶');
+      expect(el.shadowRoot!.querySelector('.replay-button')).not.toBeNull();
+    });
+
+    it('sends custom css and applies night mode classes', async () => {
+      const fetchMock = mockFetchOk(makeResponse({ css: '.card { color: red; }' }));
+      const el = createPreview({
+        'template-front': '{{Front}}',
+        'template-back': '{{Front}}',
+        fields: JSON.stringify({ Front: 'Q' }),
+        css: '.card { color: red; }',
+        'night-mode': '',
+      });
+      const done = waitForEvent<RenderCompleteDetail>(el, 'render-complete');
+      document.body.appendChild(el);
+      await done;
+
+      const body = JSON.parse(
+        (fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string
+      );
+      expect(body.css).toBe('.card { color: red; }');
+      const content = el.shadowRoot!.querySelector('.content')!;
+      expect(content.classList.contains('night_mode')).toBe(true);
+      expect(content.classList.contains('nightMode')).toBe(true);
+    });
+
+    it('uses the service-url attribute when provided', async () => {
+      const fetchMock = mockFetchOk(makeResponse());
+      const el = createPreview({
+        'template-front': '{{Front}}',
+        'template-back': '{{Front}}',
+        fields: JSON.stringify({ Front: 'Q' }),
+        'service-url': 'http://localhost:9003/',
+      });
+      const done = waitForEvent<RenderCompleteDetail>(el, 'render-complete');
+      document.body.appendChild(el);
+      await done;
+
+      expect((fetchMock.mock.calls[0] as [string])[0]).toBe('http://localhost:9003/render');
+    });
+
+    it('debounces attribute changes into a single service call', async () => {
+      const fetchMock = mockFetchOk(makeResponse());
+      const el = createPreview({
+        'template-front': '{{Front}}',
+        'template-back': '{{Front}}',
+        fields: JSON.stringify({ Front: 'Q' }),
+      });
+      document.body.appendChild(el);
+      // Burst of changes before the debounce window elapses
+      el.setAttribute('side', 'answer');
+      el.setAttribute('fields', JSON.stringify({ Front: 'Q2' }));
+      await waitForEvent<RenderCompleteDetail>(el, 'render-complete');
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(
+        (fetchMock.mock.calls[0] as [string, RequestInit])[1].body as string
+      );
+      expect(body.fields).toEqual({ Front: 'Q2' });
+    });
+  });
+
+  describe('error handling', () => {
+    it('surfaces service template errors via render-error', async () => {
+      mockFetchError(400, { detail: 'unknown field: Missing' });
+      const el = createPreview({
+        'template-front': '{{Missing}}',
+        'template-back': '{{Missing}}',
+        fields: JSON.stringify({ Front: 'Q' }),
+      });
+      const done = waitForEvent<RenderErrorDetail>(el, 'render-error');
+      document.body.appendChild(el);
+      const detail = await done;
+
+      expect(detail.message).toBe('unknown field: Missing');
+      const content = el.shadowRoot!.querySelector('.content')!;
+      expect(content.classList.contains('error')).toBe(true);
+      expect(content.textContent).toContain('unknown field: Missing');
+    });
+
+    it('errors without calling the service when fields are missing', async () => {
+      const fetchMock = mockFetchOk(makeResponse());
+      const el = createPreview({
+        'template-front': '{{Front}}',
+        'template-back': '{{Front}}',
+      });
+      const done = waitForEvent<RenderErrorDetail>(el, 'render-error');
+      document.body.appendChild(el);
+      const detail = await done;
+
+      expect(detail.message).toContain('fields');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('surfaces network failures via render-error', async () => {
+      (globalThis as Record<string, unknown>).fetch = jest.fn(() =>
+        Promise.reject(new TypeError('Failed to fetch'))
+      );
+      const el = createPreview({
+        'template-front': '{{Front}}',
+        'template-back': '{{Front}}',
+        fields: JSON.stringify({ Front: 'Q' }),
+      });
+      const done = waitForEvent<RenderErrorDetail>(el, 'render-error');
+      document.body.appendChild(el);
+      const detail = await done;
+
+      expect(detail.message).toBe('Failed to fetch');
+    });
+  });
+
+  describe('properties', () => {
+    it('reflects attributes through properties', () => {
+      const el = createPreview({
+        'template-front': '{{Word}}',
+        'template-back': '{{Word}}<br>{{Definition}}',
+        fields: JSON.stringify({ Word: 'hola' }),
+        side: 'answer',
+        cloze: '',
+        'card-ord': '2',
+        'service-url': 'http://localhost:9003',
+      });
+
+      expect(el.templateFront).toBe('{{Word}}');
+      expect(el.templateBack).toBe('{{Word}}<br>{{Definition}}');
+      expect(el.fields).toEqual({ Word: 'hola' });
+      expect(el.side).toBe('answer');
+      expect(el.cloze).toBe(true);
+      expect(el.cardOrd).toBe(2);
+      expect(el.serviceUrl).toBe('http://localhost:9003');
+    });
+
+    it('defaults cardOrd to null and serviceUrl to the public service', () => {
+      const el = createPreview({});
+      expect(el.cardOrd).toBeNull();
+      expect(el.serviceUrl).toBe(DEFAULT_SERVICE_URL);
+      expect(el.cloze).toBe(false);
+      expect(el.side).toBe('question');
     });
   });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,9 +11,19 @@ export default defineConfig({
     baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',
   },
-  webServer: {
-    command: 'npx serve -l 3000 .',
-    port: 3000,
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: [
+    {
+      command: 'npx serve -l 3000 .',
+      port: 3000,
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      // Local rendering service (on the Mac mini the deployed service already
+      // listens on 9003, so an already-running instance is reused locally)
+      command: 'server/.venv/bin/python -m uvicorn server.app:app --port 9003',
+      url: 'http://localhost:9003/healthz',
+      reuseExistingServer: !process.env.CI,
+      timeout: 60000,
+    },
+  ],
 });


### PR DESCRIPTION
Closes #22.

## What changed

**Component (`js/src/component.ts`)** — `<anki-card-preview>` now renders via the rendering service (Anki's real engine) instead of the WASM module. The WASM dependency is gone from the component bundle; the Rust/WASM library API is untouched.

- New attributes: `service-url` (default `https://anki-renderer.bjblabs.com/api`), `cloze`, `card-ord` (0-indexed; defaults to the first card Anki would generate). `card-ordinal` and `default-styles` are gone — the service returns the note type CSS (stock by default), which is always injected.
- Response CSS goes into the shadow DOM with standard Anki classes on the container (`.card`, plus `.night_mode`/`.nightMode` in night mode).
- `[anki:play:q:N]` audio markers render as a ▶ placeholder; parsed av tags are exposed on `render-complete` (`card.questionAvTags`).
- Attribute changes are debounced (50ms) into one service call; stale in-flight responses are dropped.
- `render-complete` detail now includes `card`, `cards`, and `ankiVersion` alongside `content`/`side`.

**Demo** — drives the component against the live service; cloze checkbox + card ordinal controls; engine version from `/healthz` in the footer; new "Punctuated Field Names" example using the issue #20 repro field (`Source (book, article, etc.)`) — verified rendering in the browser. Vite dev now serves the repo `dist/` at `/lib/` so dev and prod share one import path (the old `../../dist/` dev import 404'd).

**Tests**
- Jest: component tests now exercise the real render flow in jsdom with mocked `fetch` — 18 tests covering request shape, card selection, av markers, night mode, debouncing, and error paths.
- Playwright: 15 e2e tests against a local service instance (started via `playwright.config.ts` webServer from `server/.venv`; an already-running instance on 9003 is reused locally). Includes the #20 repro and an assertion that no `.wasm`/`pkg/` requests are made.

**CI** — new `server-tests` job (pip install + pytest on `server/tests/`, no AnkiConnect needed); the existing job sets up Python and the service venv so e2e tests run against a local service.

**README** — component docs rewritten for the service-backed API; media-file and audio limitations documented; stale "WASM still powers the demo" claim fixed.

`server/` is unchanged — no redeploy needed.

## Verification

- `server/.venv/bin/python -m pytest server/tests/` — 18 passed
- `npm run build && npx jest` — 53 passed (typecheck clean)
- `npx playwright test` — 15 passed
- Demo checked in a real browser: punctuated field name renders, cloze example shows `[...] is the capital of France`, footer shows "Rendering engine: Anki 25.09.4"

🤖 Generated with [Claude Code](https://claude.com/claude-code)